### PR TITLE
Use a build specific workdir so there's no conflict between runs

### DIFF
--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -6,7 +6,7 @@ require 'rexml/document'
 
 module TestSummaryBuildkitePlugin
   module Input
-    WORKDIR = 'tmp/test-summary'
+    WORKDIR = "/tmp/test-summary/#{ENV['BUILDKITE_BUILD_ID']}"
     DEFAULT_JOB_ID_REGEX = /(?<job_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
 
     def self.create(type:, **options)

--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -15,6 +15,10 @@ module TestSummaryBuildkitePlugin
       TYPES[type].new(options)
     end
 
+    def self.clean_up
+      FileUtils.rm_rf(WORKDIR)
+    end
+
     class Base
       attr_reader :label, :artifact_path, :options
 

--- a/lib/test_summary_buildkite_plugin/runner.rb
+++ b/lib/test_summary_buildkite_plugin/runner.rb
@@ -22,6 +22,8 @@ module TestSummaryBuildkitePlugin
       else
         annotate(markdown)
       end
+
+      Input.clean_up
     end
 
     def annotate(markdown)


### PR DESCRIPTION
The test-summary plugin was written with the assumption the operations would run in a docker image. We're using a non-released change that runs directly in the plugin directory. This means by default all the runs will download files to `<plugin_checkout>/tmp/test-summary` which is not cleaned between runs.

This PR changes the directory to /tmp and adds the build id to the path.

Test run here:
https://buildkite.com/instacart/carrot-shoppers-shoppers/builds/2414#0181732a-f2d2-4946-8ca2-7f5ce64bc180
