### PR TITLE
Use temp dir instead of dir with Build ID in the name

### DIFF
--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -7,7 +7,7 @@ require 'rexml/document'
 
 module TestSummaryBuildkitePlugin
   module Input
-    WORKDIR = Dir.tmpdir()
+    WORKDIR = Dir.mktmpdir
     DEFAULT_JOB_ID_REGEX = /(?<job_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
 
     def self.create(type:, **options)

--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'tmpdir'
 
 # We don't use nokogiri because we use an alpine-based docker image
 # And adding the required dependencies triples the size of the image
@@ -6,7 +7,7 @@ require 'rexml/document'
 
 module TestSummaryBuildkitePlugin
   module Input
-    WORKDIR = "/tmp/test-summary/#{ENV['BUILDKITE_BUILD_ID']}"
+    WORKDIR = Dir.tmpdir()
     DEFAULT_JOB_ID_REGEX = /(?<job_id>[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
 
     def self.create(type:, **options)


### PR DESCRIPTION
The default job ID regex picks up the build ID in the full path instead of the job ID. There's no need for the build ID in the path, just a tempdir will do, and this also guarantees that subsequent invocations of this script (perhaps in the same build) will get a different dir.