### PR TITLE
Render templates using the root directory

### DIFF
--- a/lib/test_summary_buildkite_plugin.rb
+++ b/lib/test_summary_buildkite_plugin.rb
@@ -13,6 +13,8 @@ require 'test_summary_buildkite_plugin/truncater'
 require 'test_summary_buildkite_plugin/utils'
 require 'test_summary_buildkite_plugin/version'
 
+ROOT_DIR = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
 module TestSummaryBuildkitePlugin
   def self.run
     plugins = JSON.parse(ENV.fetch('BUILDKITE_PLUGINS'), symbolize_names: true)

--- a/lib/test_summary_buildkite_plugin/haml_render.rb
+++ b/lib/test_summary_buildkite_plugin/haml_render.rb
@@ -3,7 +3,7 @@
 module TestSummaryBuildkitePlugin
   class HamlRender
     def self.render(name, params, folder: nil)
-      filename = %W[templates/#{folder}/#{name}.html.haml templates/#{name}.html.haml].find { |f| File.exist?(f) }
+      filename = %W[#{ROOT_DIR}/templates/#{folder}/#{name}.html.haml #{ROOT_DIR}/templates/#{name}.html.haml].find { |f| File.exist?(f) }
       if filename
         engine = Haml::Engine.new(File.read(filename), escape_html: true)
         engine.render(Object.new, params)

--- a/lib/test_summary_buildkite_plugin/haml_render.rb
+++ b/lib/test_summary_buildkite_plugin/haml_render.rb
@@ -7,6 +7,8 @@ module TestSummaryBuildkitePlugin
       if filename
         engine = Haml::Engine.new(File.read(filename), escape_html: true)
         engine.render(Object.new, params)
+      else
+        Utils.log_error("Cannot find template with name #{name}")
       end
     end
   end

--- a/lib/test_summary_buildkite_plugin/haml_render.rb
+++ b/lib/test_summary_buildkite_plugin/haml_render.rb
@@ -3,15 +3,10 @@
 module TestSummaryBuildkitePlugin
   class HamlRender
     def self.render(name, params, folder: nil)
-      filename = [
-          File.join(ROOT_DIR, "templates", folder, "#{name}.html.haml"), 
-          File.join(ROOT_DIR, "templates", "#{name}.html.haml")
-        ].find { |f| File.exist?(f) }
+      filename = %W[#{ROOT_DIR}/templates/#{folder}/#{name}.html.haml #{ROOT_DIR}/templates/#{name}.html.haml].find { |f| File.exist?(f) }
       if filename
         engine = Haml::Engine.new(File.read(filename), escape_html: true)
         engine.render(Object.new, params)
-      else
-        puts "Cannot find template with name #{name}, #{ROOT_DIR}/templates/#{folder}/#{name}.html.haml"
       end
     end
   end

--- a/lib/test_summary_buildkite_plugin/haml_render.rb
+++ b/lib/test_summary_buildkite_plugin/haml_render.rb
@@ -4,8 +4,8 @@ module TestSummaryBuildkitePlugin
   class HamlRender
     def self.render(name, params, folder: nil)
       filename = [
-          Files.join(ROOT_DIR, "templates", folder, "#{name}.html.haml"), 
-          Files.join(ROOT_DIR, "templates", "#{name}.html.haml")
+          File.join(ROOT_DIR, "templates", folder, "#{name}.html.haml"), 
+          File.join(ROOT_DIR, "templates", "#{name}.html.haml")
         ].find { |f| File.exist?(f) }
       if filename
         engine = Haml::Engine.new(File.read(filename), escape_html: true)

--- a/lib/test_summary_buildkite_plugin/haml_render.rb
+++ b/lib/test_summary_buildkite_plugin/haml_render.rb
@@ -3,12 +3,15 @@
 module TestSummaryBuildkitePlugin
   class HamlRender
     def self.render(name, params, folder: nil)
-      filename = %W[#{ROOT_DIR}/templates/#{folder}/#{name}.html.haml #{ROOT_DIR}/templates/#{name}.html.haml].find { |f| File.exist?(f) }
+      filename = [
+          Files.join(ROOT_DIR, "templates", folder, "#{name}.html.haml"), 
+          Files.join(ROOT_DIR, "templates", "#{name}.html.haml")
+        ].find { |f| File.exist?(f) }
       if filename
         engine = Haml::Engine.new(File.read(filename), escape_html: true)
         engine.render(Object.new, params)
       else
-        Utils.log_error("Cannot find template with name #{name}")
+        puts "Cannot find template with name #{name}, #{ROOT_DIR}/templates/#{folder}/#{name}.html.haml"
       end
     end
   end

--- a/lib/test_summary_buildkite_plugin/input.rb
+++ b/lib/test_summary_buildkite_plugin/input.rb
@@ -13,7 +13,7 @@ module TestSummaryBuildkitePlugin
     def self.create(type:, **options)
       type = type.to_sym
       raise StandardError, "Unknown file type: #{type}" unless TYPES.key?(type)
-      TYPES[type].new(options)
+      TYPES[type].new(**options)
     end
 
     class Base


### PR DESCRIPTION
The previous PR broke template rendering because the template rendering code assumed the program was being run from inside the root of the plugin. "ROOT_DIR" is defined globally to point the root of the project so templates can be opened relative to that path.

This fixes template rendering for the batching pipeline:
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/1634785/187795975-9ffd0e59-f627-4046-a976-5df5cbf1d0b4.png">

Before it just looked like this:
<img width="1165" alt="image" src="https://user-images.githubusercontent.com/1634785/187796045-db2b2903-4c7c-4c20-a302-0fac43661659.png">
