### PR TITLE
Fix issue where bundler was installing plugin gems and project gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Add a build step using the test-summary plugin:
 ```yaml
   - label: annotate
     plugins:
-      - instacart/test-summary#v1.14.0:
+      - instacart/test-summary#v1.14.3:
           inputs:
             - label: rspec
               artifact_path: artifacts/rspec*

--- a/bin/setup
+++ b/bin/setup
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 PLUGIN_BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
-
+echo "PLUGIN_BASEDIR=${PLUGIN_BASEDIR}"
 bundle install --quiet --gemfile="${PLUGIN_BASEDIR}/Gemfile"
 
 # Do any other automated setup that you need to do here

--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PLUGIN_BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
-echo "PLUGIN_BASEDIR=${PLUGIN_BASEDIR}"
-bundle install --gemfile="${PLUGIN_BASEDIR}/Gemfile"
-
-# Do any other automated setup that you need to do here
+bundle install

--- a/bin/setup
+++ b/bin/setup
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-bundle install
+bundle install --quiet

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,6 @@ set -euo pipefail
 
 PLUGIN_BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 echo "PLUGIN_BASEDIR=${PLUGIN_BASEDIR}"
-bundle install --quiet --gemfile="${PLUGIN_BASEDIR}/Gemfile"
+bundle install --gemfile="${PLUGIN_BASEDIR}/Gemfile"
 
 # Do any other automated setup that you need to do here

--- a/hooks/post-artifact
+++ b/hooks/post-artifact
@@ -18,8 +18,8 @@ trap on_failure ERR
 PLUGIN_BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 
 if [[ ${BUILDKITE_PLUGIN_TEST_SUMMARY_RUN_WITHOUT_DOCKER:-false} = true ]]; then
-    $PLUGIN_BASEDIR/bin/setup
-    $PLUGIN_BASEDIR/bin/run
+    BUNDLE_GEMFILE="$PLUGIN_BASEDIR/Gemfile" $PLUGIN_BASEDIR/bin/setup
+    BUNDLE_GEMFILE="$PLUGIN_BASEDIR/Gemfile" bundler exec $PLUGIN_BASEDIR/bin/run
 else
     TAG=$(git describe --tags --exact-match 2> /dev/null || true)
 


### PR DESCRIPTION
Due to how bundler uses `require 'bundler/setup'` in Ruby which will also install gems, the plugin would first install the gems of the plugin in bin/setup then (attempt) to install the gems of the pipeline. This was failing for a new project so I looked into it. Setting BUNDLE_GEMFILE and using bundler exec will ensure the library will only use the gems declared in the plugin's Gemfile.
