### PR TITLE
Support running the plugin when artifacts aren't uploaded from the step

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Add a build step using the test-summary plugin:
 ```yaml
   - label: annotate
     plugins:
-      - instacart/test-summary#v1.14.3:
+      - instacart/test-summary#v1.15.0:
           inputs:
             - label: rspec
               artifact_path: artifacts/rspec*

--- a/hooks/post-artifact
+++ b/hooks/post-artifact
@@ -10,5 +10,8 @@ trap on_failure ERR
 
 # if there are no artifacts uploaded from the step, the post-artifact hook won't be run
 if [[ -n "${BUILDKITE_ARTIFACT_PATHS}" ]]; then
+    echo "Running test-summary in post-artifact since step 'artifact_paths' were found"
     run_plugin
+else
+    echo "Skipping since plugin was run in post-command"
 fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -8,5 +8,8 @@ source "${PLUGIN_BASEDIR}/lib/helpers.bash"
 
 # if there are no artifacts uploaded from the step, the post-artifact hook won't be run
 if [[ -z "${BUILDKITE_ARTIFACT_PATHS}" ]]; then
+    echo "Running test-summary in post-command since step 'artifact_paths' were not found"
     run_plugin
+else
+    echo "Skipping, plugin will be run in post-artifact since since step 'artifact_paths' were found"
 fi

--- a/hooks/post-command
+++ b/hooks/post-command
@@ -1,14 +1,12 @@
 #!/bin/bash
 
-set -eEuo pipefail
+set -euo pipefail
 
 PLUGIN_BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 # shellcheck source=./lib/helpers.bash
 source "${PLUGIN_BASEDIR}/lib/helpers.bash"
 
-trap on_failure ERR
-
 # if there are no artifacts uploaded from the step, the post-artifact hook won't be run
-if [[ -n "${BUILDKITE_ARTIFACT_PATHS}" ]]; then
+if [[ -z "${BUILDKITE_ARTIFACT_PATHS}" ]]; then
     run_plugin
 fi

--- a/lib/helpers.bash
+++ b/lib/helpers.bash
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+function on_failure() {
+    echo "Command failed with exit status: $?"
+    if [[ "${BUILDKITE_PLUGIN_TEST_SUMMARY_FAIL_ON_ERROR:-false}" != "true" ]]; then
+        echo "Suppressing failure so pipeline can continue (if you do not want this behaviour, set fail_on_error to true)"
+        exit 0
+    fi
+}
+
+function run_plugin() {
+    if [[ "${BUILDKITE_PLUGIN_TEST_SUMMARY_RUN_WITHOUT_DOCKER:-false}" = "true" ]]; then
+        PLUGIN_BASEDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
+        BUNDLE_GEMFILE="$PLUGIN_BASEDIR/Gemfile" "$PLUGIN_BASEDIR/bin/setup"
+        BUNDLE_GEMFILE="$PLUGIN_BASEDIR/Gemfile" bundler exec "$PLUGIN_BASEDIR/bin/run"
+    else
+        DOCKER_REPO="bugcrowd/test-summary-buildkite-plugin"
+        TAG=$(git describe --tags --exact-match 2> /dev/null || true)
+
+        if [[ -n "$TAG" ]]; then
+            echo "Found tag $TAG, pulling from docker hub"
+            IMAGE="$DOCKER_REPO:$TAG"
+            docker pull "$IMAGE"
+        else
+            echo "No tag found, building image locally"
+            IMAGE="test-summary:$BUILDKITE_JOB_ID"
+            docker build -t "$IMAGE" "$PLUGIN_BASEDIR"
+        fi
+
+        docker run --rm \
+        --mount type=bind,src="$(command -v buildkite-agent)",dst=/usr/bin/buildkite-agent \
+        --mount type=bind,src=/tmp,dst=/tmp \
+        -e BUILDKITE_BUILD_ID -e BUILDKITE_JOB_ID -e BUILDKITE_PLUGINS \
+        -e BUILDKITE_AGENT_ID -e BUILDKITE_AGENT_ACCESS_TOKEN -e BUILDKITE_AGENT_ENDPOINT   \
+        -e HTTP_PROXY -e HTTPS_PROXY \
+        "$IMAGE"
+    fi
+}


### PR DESCRIPTION
The post-artifact hook only runs if there are 'artifact_paths' set on the step. This means this plugin won't be called when used in a step that doesn't upload artifacts.

This adds a post-command hook back so that steps that upload artifacts in the command or where artifacts were uploaded in a previous step will work. The logic to run on post-command and post-artifact are inverted so the plugin will only run on one of the steps based on which one is needed.

Testing:
https://github.com/instacart/buildkite-pipeline-examples/pull/11
https://buildkite.com/instacart/buildkite-pipeline-examples-buildkite-example-python/builds/64

Showing the plugin ran once in both cases:
<img width="1098" alt="image" src="https://user-images.githubusercontent.com/1634785/203635535-180b581c-5e56-4d68-91ee-14921a60b213.png">
