### PR TITLE
Add support for ruby 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'bundler', '~> 1.16'
 gem 'haml'
+gem 'rexml'
 
 group :development, :test do
   gem 'rake', '~> 12.3'

--- a/Gemfile
+++ b/Gemfile
@@ -2,13 +2,12 @@
 
 source 'https://rubygems.org'
 
-git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
-
-gem 'bundler', '~> 1.16'
+gem 'bundler', '~> 2.3'
 gem 'haml'
+gem 'json'
 
 group :development, :test do
-  gem 'rake', '~> 12.3'
+  gem 'rake', '~> 13.0'
   gem 'rspec', '~> 3.0'
   gem 'rspec_junit_formatter'
   gem 'rubocop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,34 +5,34 @@ GEM
     commonmarker (0.17.9)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
-    diff-lcs (1.3)
-    docile (1.3.0)
+    diff-lcs (1.5.0)
+    docile (1.4.0)
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
-    json (2.1.0)
+    json (2.6.3)
     parallel (1.12.1)
     parser (2.5.1.0)
       ast (~> 2.4.0)
     powerpack (0.1.1)
     rainbow (3.0.0)
-    rake (12.3.3)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rake (13.0.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
-    rspec_junit_formatter (0.4.1)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.55.0)
       parallel (~> 1.10)
@@ -44,11 +44,12 @@ GEM
     ruby-enum (0.7.2)
       i18n
     ruby-progressbar (1.9.0)
-    simplecov (0.16.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.4)
     temple (0.8.0)
     tilt (2.0.8)
     unicode-display_width (1.3.2)
@@ -57,14 +58,15 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.16)
+  bundler (~> 2.3)
   commonmarker
   haml
-  rake (~> 12.3)
+  json
+  rake (~> 13.0)
   rspec (~> 3.0)
   rspec_junit_formatter
   rubocop
   simplecov
 
 BUNDLED WITH
-   2.1.4
+   2.3.26

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     powerpack (0.1.1)
     rainbow (3.0.0)
     rake (13.0.6)
+    rexml (3.2.5)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)
@@ -63,10 +64,11 @@ DEPENDENCIES
   haml
   json
   rake (~> 13.0)
+  rexml
   rspec (~> 3.0)
   rspec_junit_formatter
   rubocop
   simplecov
 
 BUNDLED WITH
-   2.3.26
+   2.4.16

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Add a build step using the test-summary plugin:
 ```yaml
   - label: annotate
     plugins:
-      - instacart/test-summary#v1.16.0:
+      - instacart/test-summary#v1.17.0:
           inputs:
             - label: RSpec
               artifact_path: artifacts/rspec*


### PR DESCRIPTION
* rexml gem is a bundled gem since Ruby 3.0.0. 
* So it must be added to Gemfile.